### PR TITLE
Arrows redraw simplified and optimized

### DIFF
--- a/src/js/classes/app.js
+++ b/src/js/classes/app.js
@@ -5,14 +5,16 @@ import {
   load_dictionary,
 } from '../libs/spellcheck_ace.js';
 import { Node } from './node';
+import { Workspace } from './workspace';
 import { data } from './data';
 import { yarnRender } from './renderer';
 import { Utils, FILETYPE } from './utils';
 
 export var App = function(name, version) {
-  var self = this;
+  const self = this;
 
-  // self
+  this.workspace = new Workspace(self);
+
   this.instance = this;
   this.data = data;
   this.name = ko.observable(name);
@@ -21,7 +23,6 @@ export var App = function(name, version) {
   this.deleting = ko.observable(null);
   this.nodes = ko.observableArray([]);
   this.cachedScale = 1;
-  this.canvas;
   this.context;
   this.nodeHistory = [];
   this.nodeFuture = [];
@@ -49,19 +50,7 @@ export var App = function(name, version) {
   this.hasTouchScreen = false;
   // this.fs = fs;
 
-  this.UPDATE_ARROWS_THROTTLE_MS = 16;
 
-  this.timer = undefined;
-  this.startUpdatingArrows = () => {
-    self.stopUpdatingArrows();
-    self.timer = setInterval(self.updateArrows, this.UPDATE_ARROWS_THROTTLE_MS);
-  };
-  this.stopUpdatingArrows = () => {
-    if (self.timer) {
-      window.clearInterval(self.timer);
-      self.timer = undefined;
-    }
-  }
 
   // this.parser = new ini.Parser();
   this.configFilePath = null;
@@ -111,9 +100,11 @@ export var App = function(name, version) {
     $('#app').show();
     ko.applyBindings(self, $('#app')[0]);
 
-    self.canvas = $('.arrows')[0];
-    self.context = self.canvas.getContext('2d');
-    self.newNode().title('Start');
+    for (let i=0; i<200; ++i) {
+      self.newNode().title('Node'+i).body('[[link|Node' + (i+1) +']][[link|Node' + (i+5) + ']]');
+    }
+
+    // self.newNode().title('Start');
 
     // search field enter
     self.$searchField.on('keyup', function(e) {
@@ -162,8 +153,6 @@ export var App = function(name, version) {
         });
       },
     };
-    // updateArrows
-    // setInterval(function() { self.updateArrows(); }, 16);
 
     // drag node holder around
     (function() {
@@ -174,7 +163,6 @@ export var App = function(name, version) {
       var MarqRect = { x1: 0, y1: 0, x2: 0, y2: 0 };
       var MarqueeOffset = [0, 0];
       var midClickHeld = false;
-      var updateArrowsInterval;
 
       $('.nodes').on('pointerdown', function(e) {
         if (e.button == 1) {
@@ -192,10 +180,9 @@ export var App = function(name, version) {
         MarqueeOffset[0] = 0;
         MarqueeOffset[1] = 0;
 
-        if (!e.altKey && !e.shiftKey) self.deselectAllNodes();
-
-        // updateArrowsInterval = setInterval(self.updateArrowsThrottled, 16);
-        self.startUpdatingArrows();
+        if (!e.altKey && !e.shiftKey) {
+          self.deselectAllNodes();
+        }
       });
 
       $('.nodes').on('mousemove touchmove', function(e) {
@@ -227,6 +214,8 @@ export var App = function(name, version) {
               }
               offset.x = pageX;
               offset.y = pageY;
+
+              self.workspace.updateArrows();
             }
           } else {
             MarqueeOn = true;
@@ -298,10 +287,6 @@ export var App = function(name, version) {
       });
 
       $('.nodes').on('pointerup', function(e) {
-        self.stopUpdatingArrows();
-        // clearInterval(updateArrowsInterval);
-
-        // console.log("finished dragging");
         if (e.button == 1) {
           midClickHeld = false;
         }
@@ -355,7 +340,6 @@ export var App = function(name, version) {
       self.transformOrigin[1] += deltaY;
 
       self.translate();
-      self.updateArrows();
     });
 
     $(document).on('keyup keydown', function(e) {
@@ -598,8 +582,7 @@ export var App = function(name, version) {
       }
     });
 
-    // $(window).on('resize', self.updateArrowsThrottled);
-    $(window).on('resize', self.updateArrows);
+    $(window).on('resize', self.workspace.updateArrows);
 
     $(document).on('keyup keydown pointerdown pointerup', function(e) {
       if (self.editing() != null) {
@@ -1103,10 +1086,11 @@ export var App = function(name, version) {
     });
   };
 
-  this.newNode = function(updateArrows) {
+  this.newNode = function(updateLinks=true) {
     var node = new Node();
     self.nodes.push(node);
-    if (updateArrows == undefined || updateArrows == true)
+
+    if (updateLinks)
       self.updateNodeLinks();
 
     self.recordNodeAction('created', node);
@@ -1725,7 +1709,9 @@ export var App = function(name, version) {
   };
 
   this.updateNodeLinks = function() {
-    for (var i in self.nodes()) self.nodes()[i].updateLinks();
+    for (let node of self.nodes()) {
+      node.updateLinks();
+    }
   };
 
   // TODO: probably 'propagateUpdateFromNode' can be used as a
@@ -1818,93 +1804,6 @@ export var App = function(name, version) {
     });
     return result;
   };
-
-  this.updateArrows = function() {
-    self.canvas.width = $(window).width();
-    self.canvas.height = $(window).height();
-
-    var scale = self.cachedScale;
-    var offset = $('.nodes-holder').offset();
-
-    self.context.clearRect(0, 0, $(window).width(), $(window).height());
-    self.context.lineWidth = 4 * scale;
-
-    var nodes = self.nodes();
-
-    for (var i in nodes) {
-      var node = nodes[i];
-      nodes[i].tempWidth = $(node.element).width();
-      nodes[i].tempHeight = $(node.element).height();
-      nodes[i].tempOpacity = $(node.element).css('opacity');
-    }
-
-    for (var index in nodes) {
-      var node = nodes[index];
-      if (node.linkedTo().length > 0) {
-        for (var link in node.linkedTo()) {
-          link = link.trim();
-          var linked = node.linkedTo()[link];
-
-          // get origins
-          var fromX = (node.x() + node.tempWidth / 2) * scale + offset.left;
-          var fromY = (node.y() + node.tempHeight / 2) * scale + offset.top;
-          var toX = (linked.x() + linked.tempWidth / 2) * scale + offset.left;
-          var toY = (linked.y() + linked.tempHeight / 2) * scale + offset.top;
-
-          // get the normal
-          var distance = Math.sqrt(
-            (fromX - toX) * (fromX - toX) + (fromY - toY) * (fromY - toY)
-          );
-          var normal = {
-            x: (toX - fromX) / distance,
-            y: (toY - fromY) / distance,
-          };
-
-          var dist =
-            110 + 160 * (1 - Math.max(Math.abs(normal.x), Math.abs(normal.y)));
-
-          // get from / to
-          var from = {
-            x: fromX + normal.x * dist * scale,
-            y: fromY + normal.y * dist * scale,
-          };
-          var to = {
-            x: toX - normal.x * dist * scale,
-            y: toY - normal.y * dist * scale,
-          };
-
-          self.context.strokeStyle =
-            'rgba(0, 0, 0, ' + node.tempOpacity * 0.6 + ')';
-          self.context.fillStyle =
-            'rgba(0, 0, 0, ' + node.tempOpacity * 0.6 + ')';
-
-          // draw line
-          self.context.beginPath();
-          self.context.moveTo(from.x, from.y);
-          self.context.lineTo(to.x, to.y);
-          self.context.stroke();
-
-          // draw arrow
-          self.context.beginPath();
-          self.context.moveTo(to.x + normal.x * 4, to.y + normal.y * 4);
-          self.context.lineTo(
-            to.x - normal.x * 16 * scale - normal.y * 12 * scale,
-            to.y - normal.y * 16 * scale + normal.x * 12 * scale
-          );
-          self.context.lineTo(
-            to.x - normal.x * 16 * scale + normal.y * 12 * scale,
-            to.y - normal.y * 16 * scale - normal.x * 12 * scale
-          );
-          self.context.fill();
-        }
-      }
-    }
-  };
-
-  this.updateArrowsThrottled = Utils.throttle(
-    this.updateArrows,
-    this.UPDATE_ARROWS_THROTTLE_MS
-  );
 
   this.getHighlightedText = function(text) {
     text = text.replace(/\</g, '&lt;');
@@ -2137,8 +2036,8 @@ export var App = function(name, version) {
   };
 
   this.translate = function(speed) {
-    // var updateArrowsInterval = setInterval(self.updateArrowsThrottled, 16);
-    self.startUpdatingArrows();
+    if (speed)
+      self.workspace.startUpdatingArrows();
 
     $('.nodes-holder').transition(
       {
@@ -2156,9 +2055,10 @@ export var App = function(name, version) {
       speed || 0,
       'easeInQuad',
       function() {
-        self.stopUpdatingArrows();
-        // clearInterval(updateArrowsInterval);
-        // self.updateArrowsThrottled();
+        if (speed)
+          self.workspace.stopUpdatingArrows();
+        else
+          self.workspace.updateArrows();
       }
     );
   };

--- a/src/js/classes/app.js
+++ b/src/js/classes/app.js
@@ -2049,10 +2049,10 @@ export var App = function(name, version) {
       speed || 0,
       'easeInQuad',
       function() {
-        if (speed)
+        if (speed) {
           self.workspace.stopUpdatingArrows();
-        else
-          self.workspace.updateArrows();
+        }
+        self.workspace.updateArrows();
       }
     );
   };

--- a/src/js/classes/app.js
+++ b/src/js/classes/app.js
@@ -100,11 +100,7 @@ export var App = function(name, version) {
     $('#app').show();
     ko.applyBindings(self, $('#app')[0]);
 
-    for (let i=0; i<200; ++i) {
-      self.newNode().title('Node'+i).body('[[link|Node' + (i+1) +']][[link|Node' + (i+5) + ']]');
-    }
-
-    // self.newNode().title('Start');
+    self.newNode().title('Start');
 
     // search field enter
     self.$searchField.on('keyup', function(e) {

--- a/src/js/classes/app.js
+++ b/src/js/classes/app.js
@@ -49,7 +49,19 @@ export var App = function(name, version) {
   this.hasTouchScreen = false;
   // this.fs = fs;
 
-  this.UPDATE_ARROWS_THROTTLE_MS = 25;
+  this.UPDATE_ARROWS_THROTTLE_MS = 16;
+
+  this.timer = undefined;
+  this.startUpdatingArrows = () => {
+    self.stopUpdatingArrows();
+    self.timer = setInterval(self.updateArrows, this.UPDATE_ARROWS_THROTTLE_MS);
+  };
+  this.stopUpdatingArrows = () => {
+    if (self.timer) {
+      window.clearInterval(self.timer);
+      self.timer = undefined;
+    }
+  }
 
   // this.parser = new ini.Parser();
   this.configFilePath = null;
@@ -182,7 +194,8 @@ export var App = function(name, version) {
 
         if (!e.altKey && !e.shiftKey) self.deselectAllNodes();
 
-        updateArrowsInterval = setInterval(self.updateArrowsThrottled, 16);
+        // updateArrowsInterval = setInterval(self.updateArrowsThrottled, 16);
+        self.startUpdatingArrows();
       });
 
       $('.nodes').on('mousemove touchmove', function(e) {
@@ -285,7 +298,8 @@ export var App = function(name, version) {
       });
 
       $('.nodes').on('pointerup', function(e) {
-        clearInterval(updateArrowsInterval);
+        self.stopUpdatingArrows();
+        // clearInterval(updateArrowsInterval);
 
         // console.log("finished dragging");
         if (e.button == 1) {
@@ -341,6 +355,7 @@ export var App = function(name, version) {
       self.transformOrigin[1] += deltaY;
 
       self.translate();
+      self.updateArrows();
     });
 
     $(document).on('keyup keydown', function(e) {
@@ -583,7 +598,8 @@ export var App = function(name, version) {
       }
     });
 
-    $(window).on('resize', self.updateArrowsThrottled);
+    // $(window).on('resize', self.updateArrowsThrottled);
+    $(window).on('resize', self.updateArrows);
 
     $(document).on('keyup keydown pointerdown pointerup', function(e) {
       if (self.editing() != null) {
@@ -2123,7 +2139,8 @@ export var App = function(name, version) {
   };
 
   this.translate = function(speed) {
-    var updateArrowsInterval = setInterval(self.updateArrowsThrottled, 16);
+    // var updateArrowsInterval = setInterval(self.updateArrowsThrottled, 16);
+    self.startUpdatingArrows();
 
     $('.nodes-holder').transition(
       {
@@ -2141,8 +2158,9 @@ export var App = function(name, version) {
       speed || 0,
       'easeInQuad',
       function() {
-        clearInterval(updateArrowsInterval);
-        self.updateArrowsThrottled();
+        self.stopUpdatingArrows();
+        // clearInterval(updateArrowsInterval);
+        // self.updateArrowsThrottled();
       }
     );
   };

--- a/src/js/classes/app.js
+++ b/src/js/classes/app.js
@@ -23,7 +23,6 @@ export var App = function(name, version) {
   this.deleting = ko.observable(null);
   this.nodes = ko.observableArray([]);
   this.cachedScale = 1;
-  this.context;
   this.nodeHistory = [];
   this.nodeFuture = [];
   this.editingHistory = [];

--- a/src/js/classes/node.js
+++ b/src/js/classes/node.js
@@ -151,7 +151,7 @@ export var Node = function(options = {}) {
       self.y(-parent.offset().top + $(window).height() / 2 - 100);
     }
 
-    var updateArrowsInterval = setInterval(app.updateArrowsThrottled, 16);
+    app.workspace.startUpdatingArrows();
 
     $(self.element)
       .css({ opacity: 0, scale: 0.8, y: '-=80px', rotate: '45deg' })
@@ -165,8 +165,7 @@ export var Node = function(options = {}) {
         250,
         'easeInQuad',
         function() {
-          clearInterval(updateArrowsInterval);
-          app.updateArrowsThrottled();
+          app.workspace.stopUpdatingArrows();
         }
       );
     self.drag();
@@ -258,7 +257,7 @@ export var Node = function(options = {}) {
       'easeInQuad',
       function() {
         app.removeNode(self);
-        app.updateArrowsThrottled();
+        app.workspace.updateArrows();
       }
     );
     app.deleting(null);
@@ -309,8 +308,7 @@ export var Node = function(options = {}) {
           }
         }
 
-        //app.refresh();
-        app.updateArrowsThrottled();
+        app.workspace.updateArrows();
       }
     });
 
@@ -347,18 +345,20 @@ export var Node = function(options = {}) {
         app.deselectAllNodes();
       }
 
-      app.updateArrowsThrottled();
+      app.workspace.updateArrows();
     });
   };
 
   this.moveTo = function(newX, newY) {
+    app.workspace.startUpdatingArrows();
+
     $(self.element).clearQueue();
     $(self.element).transition(
       {
         x: newX,
         y: newY,
       },
-      app.updateArrowsThrottled,
+      app.stopUpdatingArrows,
       500
     );
   };

--- a/src/js/classes/node.js
+++ b/src/js/classes/node.js
@@ -267,13 +267,11 @@ export var Node = function(options = {}) {
   this.drag = function() {
     var dragging = false;
     var groupDragging = false;
-
     var offset = [0, 0];
     var moved = false;
 
     $(document.body).on('mousemove touchmove', function(e) {
       if (dragging) {
-        var parent = $(self.element).parent();
         const pageX =
           app.hasTouchScreen && e.changedTouches
             ? e.changedTouches[0].pageX
@@ -332,21 +330,13 @@ export var Node = function(options = {}) {
       e.stopPropagation();
     });
 
-    $(self.element).on('pointerup', function(e) {
-      if (!moved) app.mouseUpOnNodeNotMoved();
-      moved = false;
-    });
+    $(self.element).on('pointerup touchend', function(e) {
+      if (!moved)
+        app.mouseUpOnNodeNotMoved();
 
-    $(document.body).on('pointerup touchend', function(e) {
+      moved = false;
       dragging = false;
       groupDragging = false;
-      moved = false;
-
-      if (app.hasTouchScreen) {
-        app.deselectAllNodes();
-      }
-
-      app.workspace.updateArrows();
     });
   };
 

--- a/src/js/classes/node.js
+++ b/src/js/classes/node.js
@@ -166,6 +166,7 @@ export var Node = function(options = {}) {
         'easeInQuad',
         function() {
           app.workspace.stopUpdatingArrows();
+          app.workspace.updateArrows();
         }
       );
     self.drag();

--- a/src/js/classes/utils.js
+++ b/src/js/classes/utils.js
@@ -127,55 +127,11 @@ export var Utils = {
 
     return nodes;
   },
-
   now:
     Date.now ||
     function() {
       return new Date().getTime();
     },
-
-  throttle: function(func, wait, options) {
-    var self = this;
-    var context, args, result;
-    var timeout = null;
-    var previous = 0;
-
-    if (!options) options = {};
-
-    var later = function() {
-      previous = options.leading === false ? 0 : self.now();
-      timeout = null;
-      result = func.apply(context, args);
-      if (!timeout) context = args = null;
-    };
-
-    return function() {
-      var now = self.now();
-
-      if (!previous && options.leading === false) previous = now;
-
-      var remaining = wait - (now - previous);
-
-      context = this;
-      args = arguments;
-
-      if (remaining <= 0 || remaining > wait) {
-        if (timeout) {
-          clearTimeout(timeout);
-          timeout = null;
-        }
-
-        previous = now;
-        result = func.apply(context, args);
-
-        if (!timeout) context = args = null;
-      } else if (!timeout && options.trailing !== false) {
-        timeout = setTimeout(later, remaining);
-      }
-
-      return result;
-    };
-  },
   langs: [
     ['Afrikaans', ['af-ZA']],
     ['Bahasa Indonesia', ['id-ID']],

--- a/src/js/classes/workspace.js
+++ b/src/js/classes/workspace.js
@@ -7,6 +7,7 @@ export const Workspace = function(app) {
   this.context = self.canvas.getContext('2d');
 
   this.updateArrowsInterval = undefined;
+  this.isDrawingArrows = false;
 
   // startUpdatingArrows
   //
@@ -30,6 +31,12 @@ export const Workspace = function(app) {
   //
   // Redraws all the arrows on the workspace
   this.updateArrows = function() {
+    if (self.isDrawingArrows)
+      return;
+
+    self.isDrawingArrows = true;
+
+    this.isDrawingArrows = false;
     const nodes = app.nodes();
     const offset = $('.nodes-holder').offset();
     const scale = app.cachedScale;
@@ -80,12 +87,17 @@ export const Workspace = function(app) {
             )
           ) * scale;
 
+          const from = {
+            x: fromX + normal.x * dist,
+            y: fromY + normal.y * dist,
+          };
+
           const to = {
             x: toX - normal.x * dist,
             y: toY - normal.y * dist,
           };
 
-          linePoints.push({x1: fromX, y1: fromY, x2: to.x, y2: to.y});
+          linePoints.push({x1: from.x, y1: from.y, x2: to.x, y2: to.y});
           arrowPoints.push({
             x1: to.x + normal.x * arrowLength,
             y1: to.y + normal.y * arrowLength,
@@ -94,25 +106,6 @@ export const Workspace = function(app) {
             x3: to.x - normal.x * arrowWidth + normal.y * arrowHeight,
             y3: to.y - normal.y * arrowWidth - normal.x * arrowHeight
           });
-
-          // // draw line
-          // self.context.beginPath();
-          // self.context.moveTo(from.x, from.y);
-          // self.context.lineTo(to.x, to.y);
-          // self.context.stroke();
-
-          // // draw arrow
-          // self.context.beginPath();
-          // self.context.moveTo(to.x + normal.x * 10, to.y + normal.y * 10);
-          // self.context.lineTo(
-          //   to.x - normal.x * arrowWidth - normal.y * arrowHeight,
-          //   to.y - normal.y * arrowWidth + normal.x * arrowHeight
-          // );
-          // self.context.lineTo(
-          //   to.x - normal.x * arrowWidth + normal.y * arrowHeight,
-          //   to.y - normal.y * arrowWidth - normal.x * arrowHeight
-          // );
-          // self.context.fill();
         }
       }
     }
@@ -133,5 +126,7 @@ export const Workspace = function(app) {
       self.context.lineTo(arrow.x3, arrow.y3);
     }
     self.context.fill();
+
+    self.isDrawingArrows = false;
   };
 };

--- a/src/js/classes/workspace.js
+++ b/src/js/classes/workspace.js
@@ -56,17 +56,17 @@ export const Workspace = function(app) {
 
     for (let node of nodes) {
       node.halfWidth = $(node.element).width() / 2;
-      node.halfHeigth = $(node.element).height() / 2;
+      node.halfHeight = $(node.element).height() / 2;
     }
 
     for (let node of nodes) {
       if (node.linkedTo().length) {
         const fromX = (node.x() + node.halfWidth) * scale + offset.left;
-        const fromY = (node.y() + node.halfHeigth) * scale + offset.top;
+        const fromY = (node.y() + node.halfHeight) * scale + offset.top;
 
         for (let linked of node.linkedTo()) {
           const toX = (linked.x() + linked.halfWidth) * scale + offset.left;
-          const toY = (linked.y() + linked.halfHeigth) * scale + offset.top;
+          const toY = (linked.y() + linked.halfHeight) * scale + offset.top;
 
           // Get the normalized direction from -> to
           const distance = Math.sqrt(

--- a/src/js/classes/workspace.js
+++ b/src/js/classes/workspace.js
@@ -1,0 +1,137 @@
+
+export const Workspace = function(app) {
+  const UPDATE_ARROWS_THROTTLE_MS = 16;
+  const self = this;
+
+  this.canvas = $('.arrows')[0];
+  this.context = self.canvas.getContext('2d');
+
+  this.updateArrowsInterval = undefined;
+
+  // startUpdatingArrows
+  //
+  // Keeps updating arrows during transition
+  this.startUpdatingArrows = () => {
+    self.stopUpdatingArrows();
+    self.updateArrowsInterval = setInterval(self.updateArrows, UPDATE_ARROWS_THROTTLE_MS);
+  };
+
+  // stopUpdatingArrows
+  //
+  // Stops updating arrows after transition
+  this.stopUpdatingArrows = () => {
+    if (self.updateArrowsInterval) {
+      window.clearInterval(self.updateArrowsInterval);
+      self.updateArrowsInterval = undefined;
+    }
+  }
+
+  // updateArrows
+  //
+  // Redraws all the arrows on the workspace
+  this.updateArrows = function() {
+    const nodes = app.nodes();
+    const offset = $('.nodes-holder').offset();
+    const scale = app.cachedScale;
+    const lineWidth = 3 * scale;
+    const arrowWidth = 8 * scale;
+    const arrowHeight = 6 * scale;
+    const arrowLength = 10;
+
+    const linePoints = [];
+    const arrowPoints = [];
+
+    self.canvas.width = $(window).width();
+    self.canvas.height = $(window).height();
+
+    // self.context.clearRect(0, 0, self.canvas.width, self.canvas.height);
+    self.context.lineWidth = lineWidth;
+    self.context.strokeStyle = self.context.fillStyle = 'rgba(0, 0, 0, 1)';
+
+    for (let node of nodes) {
+      node.halfWidth = $(node.element).width() / 2;
+      node.halfHeigth = $(node.element).height() / 2;
+    }
+
+    for (let node of nodes) {
+      if (node.linkedTo().length) {
+        const fromX = (node.x() + node.halfWidth) * scale + offset.left;
+        const fromY = (node.y() + node.halfHeigth) * scale + offset.top;
+
+        for (let linked of node.linkedTo()) {
+          const toX = (linked.x() + linked.halfWidth) * scale + offset.left;
+          const toY = (linked.y() + linked.halfHeigth) * scale + offset.top;
+
+          // Get the normalized direction from -> to
+          const distance = Math.sqrt(
+            (fromX - toX) * (fromX - toX) + (fromY - toY) * (fromY - toY)
+          );
+
+          const normal = {
+            x: (toX - fromX) / distance,
+            y: (toY - fromY) / distance,
+          };
+
+          const dist = (
+            110 + (
+              160 * (
+                1 - Math.max(Math.abs(normal.x), Math.abs(normal.y))
+              )
+            )
+          ) * scale;
+
+          const to = {
+            x: toX - normal.x * dist,
+            y: toY - normal.y * dist,
+          };
+
+          linePoints.push({x1: fromX, y1: fromY, x2: to.x, y2: to.y});
+          arrowPoints.push({
+            x1: to.x + normal.x * arrowLength,
+            y1: to.y + normal.y * arrowLength,
+            x2: to.x - normal.x * arrowWidth - normal.y * arrowHeight,
+            y2: to.y - normal.y * arrowWidth + normal.x * arrowHeight,
+            x3: to.x - normal.x * arrowWidth + normal.y * arrowHeight,
+            y3: to.y - normal.y * arrowWidth - normal.x * arrowHeight
+          });
+
+          // // draw line
+          // self.context.beginPath();
+          // self.context.moveTo(from.x, from.y);
+          // self.context.lineTo(to.x, to.y);
+          // self.context.stroke();
+
+          // // draw arrow
+          // self.context.beginPath();
+          // self.context.moveTo(to.x + normal.x * 10, to.y + normal.y * 10);
+          // self.context.lineTo(
+          //   to.x - normal.x * arrowWidth - normal.y * arrowHeight,
+          //   to.y - normal.y * arrowWidth + normal.x * arrowHeight
+          // );
+          // self.context.lineTo(
+          //   to.x - normal.x * arrowWidth + normal.y * arrowHeight,
+          //   to.y - normal.y * arrowWidth - normal.x * arrowHeight
+          // );
+          // self.context.fill();
+        }
+      }
+    }
+
+    // Batch draw lines
+    self.context.beginPath();
+    for (let line of linePoints) {
+      self.context.moveTo(line.x1, line.y1);
+      self.context.lineTo(line.x2, line.y2);
+    }
+    self.context.stroke();
+
+    // Batch draw arrows
+    self.context.beginPath();
+    for (let arrow of arrowPoints) {
+      self.context.moveTo(arrow.x1, arrow.y1);
+      self.context.lineTo(arrow.x2, arrow.y2);
+      self.context.lineTo(arrow.x3, arrow.y3);
+    }
+    self.context.fill();
+  };
+};

--- a/src/js/classes/workspace.js
+++ b/src/js/classes/workspace.js
@@ -36,7 +36,6 @@ export const Workspace = function(app) {
 
     self.isDrawingArrows = true;
 
-    this.isDrawingArrows = false;
     const nodes = app.nodes();
     const offset = $('.nodes-holder').offset();
     const scale = app.cachedScale;


### PR DESCRIPTION
I've refactored the code related to arrows redraw. I've created a new class Workspace representing the user's workspace. For now I've only moved arrows redraw code there, but I plan to move there everything related to the workspace (marquee, nodes, arrows handling mainly).

I've optimized the updateArrows() function by:

- Drawing lines and arrows in batches (only 2 beginPath() calls per frame)
- Moving context changes out of the nested loops (I sacrificed the arrows transparency)
- Pre-calculating as much as I could imagine out of the nested loops
- Removing the updateArrowsThrottled. Now we only use timed redraws on animations. If we could get an `onFrame()` event on the .transition() method we could avoid this.

As a result arrows drawing is now fluent and is no longer a bottleneck although we still have some others:

![arrows](https://user-images.githubusercontent.com/6022674/78942791-ae992800-7aba-11ea-82d8-26f8ac03dd66.gif)
