### PR TITLE
Properly handles "intro" key when deleting node(s)

### DIFF
--- a/src/js/classes/app.js
+++ b/src/js/classes/app.js
@@ -79,18 +79,14 @@ export var App = function(name, version) {
   // inEditor
   //
   // Indicates if we are in the editor view
-  this.inEditor = () => self.editing();
+  this.inEditor = () =>
+    self.editing() && !self.ui.isDialogOpen();
 
   // inWorkspace
   //
   // Indicates if we are in the workspace view
   this.inWorkspace = () =>
-    !self.editing() && !self.ui.settingsDialogVisible();
-
-  // inSettingsDialog
-  //
-  // Indicates if we are in the settings dialog
-  this.inSettingsDialog = () => self.ui.settingsDialogVisible();
+    !self.editing() && !self.ui.isDialogOpen();
 
   // run
   //
@@ -531,19 +527,21 @@ export var App = function(name, version) {
         [...self.workspace.getSelectedNodes()] :
         [toDelete];
 
-    Swal.fire({
-      title: 'Are you sure?',
-      text: `${selected.length} ${selected.length === 1 ? 'node' : 'nodes'} will be deleted.`,
-      icon: 'warning',
-      showCancelButton: true,
-      confirmButtonText: 'Yes, delete!',
-      cancelButtonText: 'No, cancel!',
-      reverseButtons: true
-    }).then((result) => {
-      if (result.value) {
-        self.deleteNodes(selected);
-      }
-    });
+    if (selected.length) {
+      Swal.fire({
+        title: 'Are you sure?',
+        text: `${selected.length} ${selected.length === 1 ? 'node' : 'nodes'} will be deleted.`,
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonText: 'Yes, delete!',
+        cancelButtonText: 'No, cancel!',
+        reverseButtons: true
+      }).then((result) => {
+        if (result.value) {
+          self.deleteNodes(selected);
+        }
+      });
+    }
   };
 
   this.deleteNodes = function(nodes) {

--- a/src/js/classes/input.js
+++ b/src/js/classes/input.js
@@ -296,7 +296,7 @@ export const Input = function(app) {
 
     // Settings dialog shortcuts
     $(document).on('keydown', function(e) {
-      if (!app.inSettingsDialog())
+      if (!app.ui.settingsDialogVisible())
         return;
 
       switch (e.keyCode) {

--- a/src/js/classes/ui.js
+++ b/src/js/classes/ui.js
@@ -77,6 +77,12 @@ export const UI = function(app) {
       .transition({ y: '-100' }, 250);
   };
 
+  // isDialogOpen
+  this.isDialogOpen = function () {
+    return self.settingsDialogVisible() ||
+      $('.swal2-popup').length > 0;
+  };
+
   // confirmMarkupConversion
   this.confirmMarkupConversion = function () {
     Swal.fire({


### PR DESCRIPTION
When confirming a node deletion with "intro" key the node editor is no longer opened.

Additionally, the delete confirmation is not shown if the number of nodes to be deleted is zero.