### PR TITLE
Fix `getSaveData` loop intializers 🐛

### DIFF
--- a/src/js/classes/data.js
+++ b/src/js/classes/data.js
@@ -341,7 +341,7 @@ export const data = {
     if (type == FILETYPE.JSON) {
       output = JSON.stringify(content, null, '\t');
     } else if (type == FILETYPE.YARN) {
-      for (i = 0; i < content.length; i++) {
+      for (let i = 0; i < content.length; i++) {
         output += 'title: ' + content[i].title + '\n';
         output += 'tags: ' + content[i].tags + '\n';
         output += 'colorID: ' + content[i].colorID + '\n';
@@ -360,14 +360,14 @@ export const data = {
         output += '===\n';
       }
     } else if (type == FILETYPE.TWEE) {
-      for (i = 0; i < content.length; i++) {
+      for (let i = 0; i < content.length; i++) {
         var tags = '';
         if (content[i].tags.length > 0) tags = ' [' + content[i].tags + ']';
         output += ':: ' + content[i].title + tags + '\n';
         output += content[i].body + '\n\n';
       }
     } else if (type == FILETYPE.TWEE2) {
-      for (i = 0; i < content.length; i++) {
+      for (let i = 0; i < content.length; i++) {
         var tags = '';
         if (content[i].tags.length > 0) tags = ' [' + content[i].tags + ']';
         var position =
@@ -377,7 +377,7 @@ export const data = {
       }
     } else if (type == FILETYPE.XML) {
       output += '<nodes>\n';
-      for (i = 0; i < content.length; i++) {
+      for (let i = 0; i < content.length; i++) {
         output += '\t<node>\n';
         output += '\t\t<title>' + content[i].title + '</title>\n';
         output += '\t\t<tags>' + content[i].tags + '</tags>\n';


### PR DESCRIPTION
Hey!

I am starting out with Yarn (and the editor), so this might be an error on my side but I can't seem to save to file types other than JSON. I've tried saving both a blank and edited file from the Electron version, as well as the web version in both Firefox and Chrome.

I tracked down the issue and it seems that the [`getSaveData` method inside the `src/classes/data.js`](https://github.com/YarnSpinnerTool/YarnEditor/blob/master/src/js/classes/data.js#L337) file is missing loop initializers for all the formats except JSON (since it gets `stringify`ed). I unfortunately wasn't able to quickly track down the commit where this happened.

This PR might not be necessary, since I might've not understood how the editor works, but it seems to fix it on my side. Feel free to close this if it is irrelevant.

Thanks for the good work on both this tool and YarnSpinner, keep it up! ✨