### PR TITLE
Implement way to disable automatic closing bracket creation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -247,6 +247,15 @@
             ></input>
             <label for="toglAutocompleteWords" title="auto-completion">💬</label>
           </span>
+          <span class="styled-checkbox hide-when-narrow">
+            <input
+            id="toglAutocompleteClosingCharacters"
+            type="checkbox"
+            data-bind="checked: app.settings.completeClosingCharacters"
+            onclick="app.toggleClosingCharactersCompletion()"
+            ></input>
+            <label for="toglAutocompleteClosingCharacters" title="Auto closing characters">()</label>
+          </span>
           <button class="bbcode-button" onclick="app.searchTextInEditor()" title="Search (Ctrl+f)">🔎</button>
           <span class="styled-checkbox hide-when-narrow">
             <input
@@ -436,6 +445,16 @@
       id="completeTags"
       type="checkbox"
       data-bind="checked: app.settings.completeTagsEnabled"
+      >
+    </div>
+
+    <!-- Auto closingCharacters -->
+    <div class="settings-item">
+      <label class="settings-label" for="completeClosingCharacters">() Complete closing characters</label>
+      <input
+      id="completeClosingCharacters"
+      type="checkbox"
+      data-bind="checked: app.settings.completeClosingCharacters"
       >
     </div>
 

--- a/src/js/classes/app.js
+++ b/src/js/classes/app.js
@@ -973,11 +973,20 @@ export var App = function(name, version) {
   };
 
   this.toggleWordCompletion = function() {
+    self.updateEditorOptions();
+  };
+
+  this.toggleClosingCharactersCompletion = function() {
+    self.updateEditorOptions();
+  };
+
+  this.updateEditorOptions = function() {
     self.editor.setOptions({
       enableBasicAutocompletion: app.settings.completeWordsEnabled(),
-      enableLiveAutocompletion: app.settings.completeWordsEnabled()
+      enableLiveAutocompletion: app.settings.completeWordsEnabled(),
+      behavioursEnabled: app.settings.completeClosingCharacters(),
     });
-  };
+  }
 
   this.advanceStoryPlayMode = function(speed = 5) {
     if (!self.previewStory.finished) {

--- a/src/js/classes/settings.js
+++ b/src/js/classes/settings.js
@@ -84,6 +84,13 @@ export const Settings = function(app) {
       true
     ).extend({ persist:'completeWordsEnabled' });
 
+  // Autocomplete closing characters
+  this.completeClosingCharacters = ko
+    .observable(storage.getItem('completeClosingCharacters') !== null ?
+      storage.getItem('completeClosingCharacters') === 'true' :
+      true
+    ).extend({ persist:'completeClosingCharacters' });
+
   // Night mode
   this.nightModeEnabled = ko
     .observable(storage.getItem('nightModeEnabled') !== null ?

--- a/src/public/mode-yarn.js
+++ b/src/public/mode-yarn.js
@@ -177,6 +177,7 @@ define('ace/mode/yarn', [
   /// Enable autocompletion via word guessing
   app.editor.setOptions({
     enableBasicAutocompletion: app.settings.completeWordsEnabled(),
-    enableLiveAutocompletion: app.settings.completeWordsEnabled()
+    enableLiveAutocompletion: app.settings.completeWordsEnabled(),
+    behavioursEnabled: app.settings.completeClosingCharacters(),
   });
 });


### PR DESCRIPTION
Fixes #210 

Before brackets and quotation marks would always close themselves after typing the opening bracket/quotation mark. This PR adds a new setting which can disable that behaviour.