### PR TITLE
Close #201 - Fix alignment buttons

### DIFF
--- a/src/js/classes/input.js
+++ b/src/js/classes/input.js
@@ -50,17 +50,16 @@ export const Input = function(app) {
       this.isLeftButtonDown = (e.button === MouseButton.Left);
 
       if (app.inWorkspace()) {
-        if (!e.altKey && !e.shiftKey)
-          app.workspace.deselectAll();
+        if (self.isDragging) {
+          switch (e.button) {
+          case MouseButton.Left:
+            app.workspace.onMarqueeStart({ x: e.pageX, y: e.pageY });
+            break;
 
-        switch (e.button) {
-        case MouseButton.Left:
-          app.workspace.onMarqueeStart({ x: e.pageX, y: e.pageY });
-          break;
-
-        case MouseButton.Middle:
-          app.workspace.onDragStart({ x: e.pageX, y: e.pageY });
-          break;
+          case MouseButton.Middle:
+            app.workspace.onDragStart({ x: e.pageX, y: e.pageY });
+            break;
+          }
         }
       } else if (app.inEditor() && e.button === MouseButton.Right) {
         app.guessPopUpHelper();


### PR DESCRIPTION
This change was needed because alignment buttons would count as "clicking" on the workspace thus deselecting the nodes you wanted to align before the proper alignment functions could be called.

I removed the 
```javascript
if (!e.altKey && !e.shiftKey)
    app.workspace.deselectAll();
```
line because I couldn't figure out what this was even for? I didn't seem to have a use, and was getting in the way of the alignment buttons functioning. If you have more insight please let me know and I'll try to come up with a different solution if that line of logic was actually useful for something.