### PR TITLE
Feat align double click

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -59,8 +59,8 @@
 
     <!-- align controls -->
     <div class="app-sort">
-      <span data-bind="click: app.workspace.alignX" title="Arrange H"></span>
-      <span data-bind="click: app.workspace.alignY" title="Arrange V"></span>
+      <span data-bind="click: app.workspace.alignH, event: { dblclick: app.workspace.reduceAlignH }" title="Arrange H"></span>
+      <span data-bind="click: app.workspace.alignV, event: { dblclick: app.workspace.reduceAlignV }" title="Arrange V"></span>
       <span data-bind="click: app.workspace.arrangeSpiral" title="Arrange Spiral"></span>
       <span data-bind="click: app.workspace.sortAlphabetical" title="Sort Alphabetically" ></span>
     </div>

--- a/src/js/classes/input.js
+++ b/src/js/classes/input.js
@@ -36,6 +36,7 @@ export const Input = function(app) {
   this.isMiddleButtonDown = false;
   this.isLeftButtonDown = false;
   this.isShiftDown = false;
+  this.isCtrlDown = false;
 
   // trackMouseEvents
   //
@@ -146,6 +147,7 @@ export const Input = function(app) {
   this.trackKeyboardEvents = function() {
     $(document).on('keyup keydown', e => {
       self.isShiftDown = e.shiftKey;
+      self.isCtrlDown = e.ctrlKey;
     });
 
     // Workspace/Editor keyboard shortcuts

--- a/src/js/classes/workspace.js
+++ b/src/js/classes/workspace.js
@@ -626,7 +626,36 @@ export const Workspace = function(app) {
   // alignY
   //
   // Align selected nodes relative to a node with the lowest y-value
-  this.alignY = function() {
+  this.alignV = function() {
+    if (app.input.isCtrlDown) {
+      self.reduceAlignV();
+      return;
+    }
+
+    const selectedNodes = app
+      .nodes()
+      .filter((el) => {
+        return el.selected;
+      })
+      .sort((a, b) => {
+        if (a.y() > b.y()) return 1;
+        if (a.y() < b.y()) return -1;
+        return 0;
+      });
+
+    if (selectedNodes.length < 2) {
+      alert('Select nodes to align');
+      return;
+    }
+
+    const referenceNode = selectedNodes.shift();
+
+    selectedNodes.forEach((node, i) => {
+      node.moveTo(referenceNode.x(), node.y());
+    });
+  };
+
+  this.reduceAlignV = function() {
     const SPACING = 210;
     const gridSize = app.settings.gridSize();
 
@@ -658,10 +687,39 @@ export const Workspace = function(app) {
     });
   };
 
-  // alignX
+  // alignH
   //
   // Align selected nodes relative to a node with the lowest x-value
-  this.alignX = function() {
+  this.alignH = function() {
+    if (app.input.isCtrlDown) {
+      self.reduceAlignH();
+      return;
+    }
+
+    const selectedNodes = app
+      .nodes()
+      .filter((el) => {
+        return el.selected;
+      })
+      .sort((a, b) => {
+        if (a.x() > b.x()) return 1;
+        if (a.x() < b.x()) return -1;
+        return 0;
+      });
+
+    if (selectedNodes.length < 2) {
+      alert('Select nodes to align');
+      return;
+    }
+    
+    const referenceNode = selectedNodes.shift();
+
+    selectedNodes.forEach((node, i) => {
+      node.moveTo(node.x(), referenceNode.y());
+    });
+  };
+
+  this.reduceAlignH = function() {
     const SPACING = 210;
     const gridSize = app.settings.gridSize();
 


### PR DESCRIPTION
Single click will align H or V but not reduce and double click or ctrl click will align H or V AND reduce (the previous behavior) as outlined in #147.

This might be a temp fix since you guys were discussing a more complex menu but I didn't want to mess with having a drop down when you click on the alignment buttons, so this is a good middle ground that you guys had discussed.