### PR TITLE
Fix issue where opening a file through Windows Explorer causes the save type to be wrong.

### DIFF
--- a/src/js/classes/data.js
+++ b/src/js/classes/data.js
@@ -195,6 +195,7 @@ export const data = {
         } else {
           data.loadData(result, type, true);
           data.setNewFileStats(fileName, filePath);
+          data.editingType(type);
         }
       },
     });


### PR DESCRIPTION
Hello! I'm not really familiar with nodejs or election, but I thought I could fix this little bug.
Let me know if this isn't the best way to do this!

Bug Reproduction steps:
- Create a .yarn file and save it.
- Close the editor.
- In Windows, double click on the file to open the editor with the file.
- Press Ctrl-S to save.
- Notice the file is saved as JSON even though it has the .yarn file extension.

This was causing import issues in my Yarn Spinner project.