### PR TITLE
Rename the project to 'Yarn Classic', as part of transfer to @blurymind

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,20 +66,20 @@ jobs:
       if: matrix.os == 'windows-latest'
       shell: pwsh
       run: |
-        echo "ARTIFACT_FILE=./electron/dist/Yarn Editor Setup ${{ steps.package-version.outputs.version }}.exe" >> $env:GITHUB_ENV
-        echo "ARTIFACT_NAME=Yarn.Editor.Setup.${{ steps.package-version.outputs.version }}.exe" >> $env:GITHUB_ENV
+        echo "ARTIFACT_FILE=./electron/dist/Yarn Classic Setup ${{ steps.package-version.outputs.version }}.exe" >> $env:GITHUB_ENV
+        echo "ARTIFACT_NAME=Yarn.Classic.Setup.${{ steps.package-version.outputs.version }}.exe" >> $env:GITHUB_ENV
 
     - name: Set environment vars for Linux
       if: matrix.os == 'ubuntu-latest'
       run: |
-        echo "ARTIFACT_FILE=./electron/dist/yarn-editor_${{ steps.package-version.outputs.version }}_amd64.snap" >> $GITHUB_ENV
-        echo "ARTIFACT_NAME=Yarn.Editor.Setup.${{ steps.package-version.outputs.version }}.snap" >> $GITHUB_ENV
+        echo "ARTIFACT_FILE=./electron/dist/yarn-classic_${{ steps.package-version.outputs.version }}_amd64.snap" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=Yarn.Classic.Setup.${{ steps.package-version.outputs.version }}.snap" >> $GITHUB_ENV
 
     - name: Set environment vars for Mac
       if: matrix.os == 'macos-latest'
       run: |
-        echo "ARTIFACT_FILE=./electron/dist/Yarn Editor-${{ steps.package-version.outputs.version }}.dmg" >> $GITHUB_ENV
-        echo "ARTIFACT_NAME=Yarn.Editor.Setup.${{ steps.package-version.outputs.version }}.dmg" >> $GITHUB_ENV
+        echo "ARTIFACT_FILE=./electron/dist/Yarn Classic-${{ steps.package-version.outputs.version }}.dmg" >> $GITHUB_ENV
+        echo "ARTIFACT_NAME=Yarn.Classic.Setup.${{ steps.package-version.outputs.version }}.dmg" >> $GITHUB_ENV
 
     - name: npm install and build
       run: cd electron && yarn install && yarn run ${{ matrix.build-task }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build](https://github.com/YarnSpinnerTool/YarnEditor/workflows/Build/badge.svg)
 
-# Yarn 🐱 🧺
+# Yarn Classic 🐱 🧺
 
 Dialogue editor created for "Night in the Woods" (and other projects) by @blurymind, @NoelFB and @infinite_ammo with contributions from @seiyria and @beeglebug. It is heavily inspired by and based on the amazing Twine software: http://twinery.org/
 It supports editing, syntax highlighting and testing for [Yarn](https://github.com/YarnSpinnerTool/YarnSpinner) and [InkleStudio Ink files](https://github.com/inkle/ink) syntax files.
@@ -28,8 +28,8 @@ alt="Yarn web app"  height="480" border="10" /></a>
 You can see planned features, vote for features or see how you can contribute at the roadmap here:
 https://trello.com/b/ZXhhOzDl/yarn-roadmap
 
-# 🎮 Game engines that bundle Yarn editor
-There are a few game engines that have YarnEditor bundled with their IDE. That means that you can use it straight in those engines, without need to save files and open files and so on. It's directly integratedin their workflow!
+# 🎮 Game engines that bundle Yarn Classic
+There are a few game engines that have Yarn Classic bundled with their IDE. That means that you can use it straight in those engines, without need to save files and open files and so on. It's directly integratedin their workflow!
 
 - Gdevelop : A full-featured, open-source game development software, allowing to create HTML5 and native games without any knowledge in a specific programming language. All the game logic is built up using an intuitive and powerful event-based system.
 https://github.com/4ian/GDevelop
@@ -47,7 +47,7 @@ https://github.com/hylyh/bondage.js
 # 🐬 Features 🦄
 
 ### Portability
-- YarnEditor has PWA version you can install and run when offline, which has a much smaller footprint than other editors using electron.
+- Yarn Classic has PWA version you can install and run when offline, which has a much smaller footprint than other editors using electron.
 - The pwa can run on mobile devices with smaller screens - you can use it on your phone and it's much easier to install.
 - There is of course also an electron version of the editor, which is slower on updates but more stable
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "build": {
-    "productName": "Yarn Editor",
+    "productName": "Yarn Classic",
     "fileAssociations": {
       "ext": "yarn",
       "name": "Yarn File",


### PR DESCRIPTION
@blurymind and I have discussed transferring this repository to his account, so that he can run it how he'd like to. As part of this, we agreed to rename the repo from 'Yarn Editor' to 'Yarn Classic'.

This PR makes the following changes:

- Updates the README to use the new name.
- Updates the built artifact filenames to use the new name.
- Updates the product name in `electron/package.json`.

Please let me know if these changes look correct (and don't break the build)!